### PR TITLE
Add Masonry Photo Gallery plugin

### DIFF
--- a/masonry-photo-gallery.css
+++ b/masonry-photo-gallery.css
@@ -1,0 +1,42 @@
+/* Style principal pour Masonry Photo Gallery */
+
+.masonry-gallery {
+    display: flex;
+    flex-wrap: wrap;
+    margin: calc(-1 * var(--mpg-gutter) / 2);
+}
+
+.masonry-gallery img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+.masonry-item {
+    box-sizing: border-box;
+    padding: calc(var(--mpg-gutter) / 2);
+    width: calc(100% / var(--mpg-columns));
+}
+
+/* Meta box */
+#mpg-container ul.masonry-images {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    overflow: hidden;
+}
+#mpg-container li.mpg-image {
+    position: relative;
+    float: left;
+    margin: 0 5px 5px 0;
+}
+#mpg-container li.mpg-image img {
+    display: block;
+}
+#mpg-container .mpg-remove {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    cursor: pointer;
+}
+

--- a/masonry-photo-gallery.js
+++ b/masonry-photo-gallery.js
@@ -1,0 +1,138 @@
+(function( $ ) {
+    // Initialisation Masonry après chargement des images
+    $( function() {
+        var galleries = $( '.masonry-gallery' );
+        galleries.each( function() {
+            var $gal = $( this );
+            $gal.imagesLoaded( function() {
+                $gal.masonry({
+                    itemSelector: '.masonry-item',
+                    percentPosition: true
+                });
+            });
+        } );
+    } );
+
+    // Admin : sélection et tri des images
+    $( document ).on( 'click', '#mpg-add-images', function( e ) {
+        e.preventDefault();
+        var frame = wp.media({
+            title: mpg_gallery.select,
+            button: { text: mpg_gallery.use },
+            multiple: true
+        });
+        frame.on( 'select', function() {
+            var ids = [];
+            var list = $( '#mpg-images' ).empty();
+            frame.state().get( 'selection' ).map( function( attachment ) {
+                attachment = attachment.toJSON();
+                ids.push( attachment.id );
+                list.append( '<li class="mpg-image" data-id="' + attachment.id + '"><img src="' + attachment.sizes.thumbnail.url + '" alt="" /><span class="dashicons dashicons-no-alt mpg-remove" title="'+mpg_gallery.remove+'"></span></li>' );
+            } );
+            $( '#mpg-images-input' ).val( ids.join( ',' ) );
+            list.sortable({
+                update: function() {
+                    var order = [];
+                    list.find( 'li' ).each( function() {
+                        order.push( $( this ).data( 'id' ) );
+                    } );
+                    $( '#mpg-images-input' ).val( order.join( ',' ) );
+                }
+            });
+        });
+        frame.open();
+    } );
+
+    $( document ).on( 'click', '.mpg-remove', function(){
+        var li = $( this ).closest( 'li' );
+        li.remove();
+        var order = [];
+        $( '#mpg-images li' ).each( function(){
+            order.push( $( this ).data( 'id' ) );
+        });
+        $( '#mpg-images-input' ).val( order.join( ',' ) );
+    });
+})( jQuery );
+
+// Enregistrement du bloc Gutenberg
+( function( wp ) {
+    if ( ! wp || ! wp.blocks ) {
+        return;
+    }
+    const { registerBlockType } = wp.blocks;
+    const { InspectorControls } = wp.blockEditor || wp.editor;
+    const { PanelBody, RangeControl, ToggleControl, SelectControl } = wp.components;
+    const { __ } = wp.i18n;
+    const { useSelect } = wp.data;
+    const { Fragment } = wp.element;
+
+    registerBlockType( 'masonry/gallery', {
+        title: __( 'Masonry Gallery', 'masonry-photo-gallery' ),
+        icon: 'format-gallery',
+        category: 'media',
+        attributes: {
+            id: { type: 'number' },
+            columns: { type: 'number', default: 3 },
+            gutter: { type: 'number', default: 10 },
+            manual: { type: 'boolean', default: true }
+        },
+        edit: ( props ) => {
+            const { attributes, setAttributes } = props;
+            const { id, columns, gutter, manual } = attributes;
+
+            const galleries = useSelect( ( select ) => {
+                return select( 'core' ).getEntityRecords( 'postType', 'masonry_gallery', { per_page: -1 } );
+            }, [] );
+
+            const images = useSelect( ( select ) => {
+                if ( ! id ) return [];
+                const post = select( 'core' ).getEntityRecord( 'postType', 'masonry_gallery', id );
+                if ( ! post || ! post.meta ) return [];
+                const ids = post.meta._masonry_gallery_images ? post.meta._masonry_gallery_images.split(',').map( Number ) : [];
+                return ids.map( ( imgId ) => select( 'core' ).getMedia( imgId ) );
+            }, [ id ] );
+
+            return (
+                <Fragment>
+                    <InspectorControls>
+                        <PanelBody title={ __( 'Options', 'masonry-photo-gallery' ) }>
+                            <SelectControl
+                                label={ __( 'Galerie', 'masonry-photo-gallery' ) }
+                                value={ id }
+                                options={ [ { label: __( 'Sélectionner', 'masonry-photo-gallery' ), value: 0 } ].concat( ( galleries || [] ).map( ( g ) => ( { label: g.title.rendered, value: g.id } ) ) ) }
+                                onChange={ ( value ) => setAttributes( { id: parseInt( value, 10 ) } ) }
+                            />
+                            <ToggleControl
+                                label={ __( 'Utiliser le tri manuel', 'masonry-photo-gallery' ) }
+                                checked={ manual }
+                                onChange={ ( val ) => setAttributes( { manual: val } ) }
+                            />
+                            <RangeControl
+                                label={ __( 'Colonnes', 'masonry-photo-gallery' ) }
+                                value={ columns }
+                                onChange={ ( val ) => setAttributes( { columns: val } ) }
+                                min={ 1 }
+                                max={ 6 }
+                            />
+                            <RangeControl
+                                label={ __( 'Espacement', 'masonry-photo-gallery' ) }
+                                value={ gutter }
+                                onChange={ ( val ) => setAttributes( { gutter: val } ) }
+                                min={ 0 }
+                                max={ 50 }
+                            />
+                        </PanelBody>
+                    </InspectorControls>
+                    <div className="masonry-gallery" style={ { '--mpg-columns': columns, '--mpg-gutter': gutter + 'px' } }>
+                        { images && images.length ? images.map( ( img ) => {
+                            if ( ! img ) return null;
+                            return <img key={ img.id } src={ img.media_details.sizes.thumbnail.source_url } alt={ img.alt_text } className="masonry-item" />;
+                        } ) : __( 'Sélectionnez une galerie', 'masonry-photo-gallery' ) }
+                    </div>
+                </Fragment>
+            );
+        },
+        save: () => null
+    } );
+} )( window.wp );
+

--- a/masonry-photo-gallery.php
+++ b/masonry-photo-gallery.php
@@ -1,0 +1,225 @@
+<?php
+/*
+Plugin Name: Masonry Photo Gallery
+Plugin URI: https://example.com
+Description: Galerie d'images en Masonry responsive.
+Version: 1.0.0
+Author: Example Author
+Author URI: https://example.com
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: masonry-photo-gallery
+Domain Path: /languages
+
+Installation:
+1. Téléversez le dossier du plugin dans le répertoire wp-content/plugins/.
+2. Activez le plugin depuis l'interface d'administration de WordPress.
+*/
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+define( 'MPG_PATH', plugin_dir_path( __FILE__ ) );
+define( 'MPG_URL', plugin_dir_url( __FILE__ ) );
+
+// Enregistrement du Custom Post Type.
+function mpg_register_cpt() {
+    $labels = [
+        'name'               => __( 'Galleries', 'masonry-photo-gallery' ),
+        'singular_name'      => __( 'Gallery', 'masonry-photo-gallery' ),
+        'add_new_item'       => __( 'Add New Gallery', 'masonry-photo-gallery' ),
+        'edit_item'          => __( 'Edit Gallery', 'masonry-photo-gallery' ),
+        'new_item'           => __( 'New Gallery', 'masonry-photo-gallery' ),
+        'view_item'          => __( 'View Gallery', 'masonry-photo-gallery' ),
+        'search_items'       => __( 'Search Galleries', 'masonry-photo-gallery' ),
+        'not_found'          => __( 'No Galleries Found', 'masonry-photo-gallery' ),
+        'not_found_in_trash' => __( 'No Galleries found in Trash', 'masonry-photo-gallery' ),
+    ];
+
+    $args = [
+        'labels'       => $labels,
+        'public'       => true,
+        'show_in_rest' => true,
+        'supports'     => [ 'title' ],
+        'menu_icon'    => 'dashicons-format-gallery',
+        'rewrite'      => [ 'slug' => 'masonry-gallery' ],
+    ];
+
+    register_post_type( 'masonry_gallery', $args );
+}
+add_action( 'init', 'mpg_register_cpt' );
+
+// Enregistrement de la métadonnée contenant les IDs d'images.
+function mpg_register_meta() {
+    register_post_meta( 'masonry_gallery', '_masonry_gallery_images', [
+        'show_in_rest' => true,
+        'single'       => true,
+        'type'         => 'string',
+        'auth_callback' => function() {
+            return current_user_can( 'edit_posts' );
+        },
+    ] );
+}
+add_action( 'init', 'mpg_register_meta' );
+
+// Ajout de la meta box.
+function mpg_add_meta_box() {
+    add_meta_box(
+        'mpg_images_box',
+        __( 'Images de la galerie', 'masonry-photo-gallery' ),
+        'mpg_meta_box_callback',
+        'masonry_gallery'
+    );
+}
+add_action( 'add_meta_boxes', 'mpg_add_meta_box' );
+
+// Affichage de la meta box.
+function mpg_meta_box_callback( $post ) {
+    wp_nonce_field( 'mpg_save_images', 'mpg_images_nonce' );
+    $value = get_post_meta( $post->ID, '_masonry_gallery_images', true );
+    $ids   = array_filter( array_map( 'absint', explode( ',', $value ) ) );
+    ?>
+    <div id="mpg-container">
+        <p>
+            <button type="button" class="button" id="mpg-add-images">
+                <?php esc_html_e( 'Ajouter des images', 'masonry-photo-gallery' ); ?>
+            </button>
+        </p>
+        <ul id="mpg-images" class="masonry-images">
+            <?php
+            if ( $ids ) {
+                foreach ( $ids as $id ) {
+                    $src = wp_get_attachment_image_src( $id, 'thumbnail' );
+                    if ( $src ) {
+                        printf(
+                            '<li class="mpg-image" data-id="%1$d"><img src="%2$s" alt="" /><span class="dashicons dashicons-no-alt mpg-remove" title="%3$s"></span></li>',
+                            $id,
+                            esc_url( $src[0] ),
+                            esc_attr__( 'Supprimer', 'masonry-photo-gallery' )
+                        );
+                    }
+                }
+            }
+            ?>
+        </ul>
+        <input type="hidden" id="mpg-images-input" name="mpg_images" value="<?php echo esc_attr( $value ); ?>" />
+    </div>
+    <?php
+}
+
+// Sauvegarde des données de la meta box.
+function mpg_save_post( $post_id ) {
+    if ( ! isset( $_POST['mpg_images_nonce'] ) || ! wp_verify_nonce( $_POST['mpg_images_nonce'], 'mpg_save_images' ) ) {
+        return;
+    }
+    if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+        return;
+    }
+    if ( ! current_user_can( 'edit_post', $post_id ) ) {
+        return;
+    }
+    if ( isset( $_POST['mpg_images'] ) ) {
+        $ids = array_filter( array_map( 'absint', explode( ',', $_POST['mpg_images'] ) ) );
+        update_post_meta( $post_id, '_masonry_gallery_images', implode( ',', $ids ) );
+    }
+}
+add_action( 'save_post_masonry_gallery', 'mpg_save_post' );
+
+// Enqueue scripts et styles front-end.
+function mpg_enqueue_scripts() {
+    wp_enqueue_style( 'masonry-photo-gallery', MPG_URL . 'masonry-photo-gallery.css', [], '1.0.0' );
+    wp_enqueue_script( 'masonry' );
+    wp_enqueue_script( 'masonry-photo-gallery', MPG_URL . 'masonry-photo-gallery.js', [ 'jquery', 'imagesloaded', 'masonry' ], '1.0.0', true );
+}
+add_action( 'wp_enqueue_scripts', 'mpg_enqueue_scripts' );
+
+// Enqueue scripts pour l'admin.
+function mpg_admin_scripts( $hook ) {
+    if ( 'post.php' !== $hook && 'post-new.php' !== $hook ) {
+        return;
+    }
+    $screen = get_current_screen();
+    if ( 'masonry_gallery' !== $screen->post_type ) {
+        return;
+    }
+    wp_enqueue_media();
+    wp_enqueue_script( 'jquery-ui-sortable' );
+    wp_enqueue_script( 'mpg-admin', MPG_URL . 'masonry-photo-gallery.js', [ 'jquery', 'jquery-ui-sortable' ], '1.0.0', true );
+    wp_localize_script( 'mpg-admin', 'mpg_gallery', [
+        'select' => __( 'Select images', 'masonry-photo-gallery' ),
+        'use'    => __( 'Use images', 'masonry-photo-gallery' ),
+        'remove' => __( 'Remove', 'masonry-photo-gallery' ),
+    ] );
+    wp_enqueue_style( 'masonry-photo-gallery', MPG_URL . 'masonry-photo-gallery.css', [], '1.0.0' );
+}
+add_action( 'admin_enqueue_scripts', 'mpg_admin_scripts' );
+
+// Shortcode.
+function mpg_gallery_shortcode( $atts ) {
+    $atts = shortcode_atts( [
+        'id'      => 0,
+        'columns' => 3,
+        'gutter'  => 10,
+        'manual'  => true,
+    ], $atts, 'masonry_gallery' );
+
+    $post_id = absint( $atts['id'] );
+    if ( ! $post_id ) {
+        return '';
+    }
+    $meta = get_post_meta( $post_id, '_masonry_gallery_images', true );
+    $ids  = array_filter( array_map( 'absint', explode( ',', $meta ) ) );
+    if ( empty( $ids ) ) {
+        return '';
+    }
+    if ( ! $atts['manual'] ) {
+        sort( $ids );
+    }
+
+    $output  = '<div class="masonry-gallery" style="--mpg-columns:' . intval( $atts['columns'] ) . ';--mpg-gutter:' . intval( $atts['gutter'] ) . 'px" aria-label="' . esc_attr__( 'Galerie', 'masonry-photo-gallery' ) . '">';
+    foreach ( $ids as $id ) {
+        $img = wp_get_attachment_image( $id, 'large', false, [ 'loading' => 'lazy', 'class' => 'masonry-item' ] );
+        if ( $img ) {
+            $output .= $img;
+        }
+    }
+    $output .= '</div>';
+    return $output;
+}
+add_shortcode( 'masonry_gallery', 'mpg_gallery_shortcode' );
+
+// Enregistrement du bloc Gutenberg.
+function mpg_register_block() {
+    if ( ! function_exists( 'register_block_type' ) ) {
+        return;
+    }
+
+    wp_register_script( 'mpg-block', MPG_URL . 'masonry-photo-gallery.js', [ 'wp-blocks', 'wp-element', 'wp-editor', 'wp-components', 'wp-data', 'wp-block-editor', 'wp-i18n' ], '1.0.0', true );
+    wp_register_style( 'mpg-block-style', MPG_URL . 'masonry-photo-gallery.css', [], '1.0.0' );
+
+    register_block_type( 'masonry/gallery', [
+        'editor_script'   => 'mpg-block',
+        'editor_style'    => 'mpg-block-style',
+        'style'           => 'masonry-photo-gallery',
+        'render_callback' => 'mpg_block_render',
+        'attributes'      => [
+            'id'      => [ 'type' => 'number' ],
+            'columns' => [ 'type' => 'number', 'default' => 3 ],
+            'gutter'  => [ 'type' => 'number', 'default' => 10 ],
+            'manual'  => [ 'type' => 'boolean', 'default' => true ],
+        ],
+    ] );
+}
+add_action( 'init', 'mpg_register_block' );
+
+// Rendu du bloc côté serveur.
+function mpg_block_render( $attributes ) {
+    $atts = shortcode_atts( [
+        'id'      => 0,
+        'columns' => 3,
+        'gutter'  => 10,
+        'manual'  => true,
+    ], $attributes );
+    return mpg_gallery_shortcode( $atts );
+}


### PR DESCRIPTION
## Summary
- add `masonry-photo-gallery.php` main plugin with CPT, metabox, shortcode and block
- add `masonry-photo-gallery.js` to initialize Masonry and Gutenberg block
- add `masonry-photo-gallery.css` for responsive Masonry styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867b95d6534832ba0ec39bb3c28b226