### PR TITLE
Fix ToggleControl spacing for new WP styles

### DIFF
--- a/masonry-photo-gallery.js
+++ b/masonry-photo-gallery.js
@@ -106,6 +106,7 @@
                                 label={ __( 'Utiliser le tri manuel', 'masonry-photo-gallery' ) }
                                 checked={ manual }
                                 onChange={ ( val ) => setAttributes( { manual: val } ) }
+                                __nextHasNoMarginBottom={ true }
                             />
                             <RangeControl
                                 label={ __( 'Colonnes', 'masonry-photo-gallery' ) }


### PR DESCRIPTION
## Summary
- ensure ToggleControl uses the new no-margin prop

## Testing
- `node --check masonry-photo-gallery.js` *(fails: Unexpected token)*
- `php -l masonry-photo-gallery.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ccf0b63c832bbc8f475929e1a3d8